### PR TITLE
* Disable bundle analyzer for now

### DIFF
--- a/static/profile/js/profileeditor.js
+++ b/static/profile/js/profileeditor.js
@@ -327,6 +327,8 @@
     GUIToObject();
 
     var newname = $('#pe_profile_name').val();
+    if (!isNaN(newname)) newname = 'Profile' + newname;
+    
     if (currentprofile !== newname) {
       // rename if already exists
       while (record.store[newname]) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,11 +21,7 @@ if (process.env.NODE_ENV !== 'development') {
 
     pluginArray.push(uglify);
 
-}
-
-if (process.env.NODE_ENV === 'development') {
-
-
+/*
     console.log('Development environment detected, enabling Bundle Analyzer');
     
     var BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
@@ -61,6 +57,7 @@ if (process.env.NODE_ENV === 'development') {
         // Log level. Can be 'info', 'warn', 'error' or 'silent'. 
         logLevel: 'info'
     }));
+*/
 
 }
 


### PR DESCRIPTION
* Prevent saving numeric profile names, which seems to break the profile storage and there's no obvious way to fix