### PR TITLE
Fix forecast behaviour (#5160)

### DIFF
--- a/lib/client/chart.js
+++ b/lib/client/chart.js
@@ -113,9 +113,6 @@ function init (client, d3, $) {
 
     return [
       utils.scaleMgdl(FOCUS_MIN)
-
-
-      
       , Math.max(utils.scaleMgdl(mgdlMax * mult), utils.scaleMgdl(targetTop * mult))
     ];
   }
@@ -689,12 +686,16 @@ function init (client, d3, $) {
   chart.getForecastData = function getForecastData () {
 
     var maxForecastAge = chart.getMaxForecastMills();
+    var pointTypes = client.settings.showForecast.split(' ');
 
-    if (client.sbx.pluginBase.forecastPoints) {
-      return _.filter(client.sbx.pluginBase.forecastPoints, function isShown (point) {
-        return point.mills < maxForecastAge && client.settings.showForecast.indexOf(point.info.type) > -1;
-      });
-    } else return [];
+    var points = pointTypes.reduce( function (points, type) {
+      return points.concat(client.sbx.pluginBase.forecastPoints[type] || []);
+    }, [] );
+
+    return _.filter(points, function isShown (point) {
+      return point.mills < maxForecastAge;
+    });
+
   };
 
   chart.setForecastTime = function setForecastTime () {
@@ -707,7 +708,7 @@ function init (client, d3, $) {
       var selectedRange = chart.createBrushedRange();
       var to = selectedRange[1].getTime();
       var maxForecastMills = to + times.mins(30).msecs;
- 
+
       if (shownForecastPoints.length > 0) {
         maxForecastMills = _.max(_.map(shownForecastPoints, function(point) { return point.mills }));
       }

--- a/lib/client/renderer.js
+++ b/lib/client/renderer.js
@@ -161,13 +161,14 @@ function init (client, d3) {
         .style('top', (d3.event.pageY + 15) + 'px');
     }
 
+    // CGM data
+
     var focusData = client.entries;
-    var shownForecastPoints = client.chart.getForecastData();
 
     // bind up the focus chart data to an array of circles
     // selects all our data into data and uses date function to get current max date
     var focusCircles = chart().focus.selectAll('circle.entry-dot').data(focusData, function genKey (d) {
-      return d.forecastType + d.mills;
+      return "cgmreading." + d.mills;
     });
 
     // if already existing then transition each circle to its new position
@@ -181,20 +182,26 @@ function init (client, d3) {
 
     focusCircles.exit().remove();
 
+    // Forecasts
+
+    var shownForecastPoints = client.chart.getForecastData();
+
     // bind up the focus chart data to an array of circles
     // selects all our data into data and uses date function to get current max date
-    var forecastCircles = chart().focus.selectAll('circle.forecast-dot').data(shownForecastPoints, client.entryToDate);
 
-    // if already existing then transition each circle to its new position
-    updateFocusCircles(forecastCircles);
-
-    // if new circle then just display
-    prepareFocusCircles(forecastCircles.enter().append('circle'))
-      .attr('class', 'forecast-dot')
-      .on('mouseover', focusCircleTooltip)
-      .on('mouseout', hideTooltip);
+    var forecastCircles = chart().focus.selectAll('circle.forecast-dot').data(shownForecastPoints, function genKey (d) {
+      return d.forecastType + d.mills;
+    });
 
     forecastCircles.exit().remove();
+
+    prepareFocusCircles(forecastCircles.enter().append('circle'))
+    .attr('class', 'forecast-dot')
+    .on('mouseover', focusCircleTooltip)
+    .on('mouseout', hideTooltip);
+
+    updateFocusCircles(forecastCircles);
+
   };
 
   renderer.addTreatmentCircles = function addTreatmentCircles (nowDate) {

--- a/lib/plugins/pluginbase.js
+++ b/lib/plugins/pluginbase.js
@@ -10,7 +10,7 @@ function init (majorPills, minorPills, statusPills, bgStatus, tooltip) {
   var pluginBase = { };
 
   pluginBase.forecastInfos = [];
-  pluginBase.forecastPoints = [];
+  pluginBase.forecastPoints = {};
 
   function findOrCreatePill (plugin) {
     var container = null;
@@ -111,7 +111,7 @@ function init (majorPills, minorPills, statusPills, bgStatus, tooltip) {
     });
 
     pluginBase.forecastInfos.push(info);
-    pluginBase.forecastPoints = pluginBase.forecastPoints.concat(points);
+    pluginBase.forecastPoints[info.type] = points;
   };
 
   return pluginBase;

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -96,7 +96,7 @@ function init () {
 
     if (sbx.pluginBase) {
       sbx.pluginBase.forecastInfos = [];
-      sbx.pluginBase.forecastPoints = [];
+      sbx.pluginBase.forecastPoints = {};
     }
 
     sbx.extendedSettings = { empty: true };


### PR DESCRIPTION
* stop focus circles from eating entries

* fix forecastCircles remove

* resolve possible key collision

* Fixes a major bug where plugins were ran against a sandbox twice, causing issues with predictions. Fixes the look ahead timings.

* Refactor of how prediction data is collected